### PR TITLE
AuditExclude merge feature

### DIFF
--- a/config/audit.php
+++ b/config/audit.php
@@ -88,6 +88,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Global exclusion merge
+    |--------------------------------------------------------------------------
+    |
+    | If set to true, the local model auditExclude array values will be
+    | merged with the config exclude array values instead of replacing 
+    | them.
+    |
+    */
+
+    'exclude_merge' => false,
+
+    /*
+    |--------------------------------------------------------------------------
     | Empty Values
     |--------------------------------------------------------------------------
     |

--- a/src/Auditable.php
+++ b/src/Auditable.php
@@ -143,7 +143,10 @@ trait Auditable
      */
     public function getAuditExclude(): array
     {
-        if ($this->auditExcludeMerge ?? false) {
+        if ( 
+            Config::get('audit.exclude_merge', false) || 
+            ($this->auditExcludeMerge ?? false) 
+        ) {
             return array_merge($this->auditExclude ?? [], Config::get('audit.exclude', []));
         }
 


### PR DESCRIPTION
Allows for merging of local auditExclude into config exclude either by global setting, or a local model property.